### PR TITLE
Fix eslint errors in fib.ts (issue #1) Pull Request

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Fixed eslint errors from fib.ts by adding parameter and return type annotations in the function declaration. This was done by adding a ": number" after both the parameter name and the parameter list. 

These changes were tested by running the command `npm run lint` and checking if the eslint errors from fib.ts were gone. This was the case, meanwhile errors from fibRoute.ts were still given which are fixed in its own appropriate branch.

Additionally, more type safety could be added using the strict equality "===" operator in the conditional statement. This is not done here but I added it later in the issue #2 pull request.