### PR TITLE
Fix eslint errors in fibRoute.ts (issue #2) Pull Request

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,10 +1,10 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
-  } else if (n == 0) {
+  } else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  } else if (n === 1) {
     return 1;
   }
 

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,8 @@
 // Endpoint for querying the fibonacci numbers
-
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Request<{ num: string }>, res: Response): void => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fixed eslint errors from fibRoute.ts by importing Request and Response from express and adding them to requests parameter which tells TypeScript that the request's route parameters will include a property called num with a type string. This improves type safety and allows thje lint to pass by avoiding unsafe access to req.params. Lastly, the void return type is added in the function declaration.

This fix was tested by running "npm run lint" and checking that the errors associated with fibRoute.ts were fixed. Since two of the errors were a direct result of fib.ts's fibonacci function being unsafe before the fixes, I applied the fixes from the fib.ts branch to this branch as well which can be seen in the file changes.